### PR TITLE
getSets and getPlayers methods for Events and Phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,12 @@ event3.on('ready', function(){
 * **getEventPhaseGroups([fromCacheTF])**
     * Returns a Promise resolving an array of `PhaseGroup` objects for this Event
     * **fromCacheTF** - boolean value for if the value should be retrieved from cache. Defaults to true
+* **getSets([fromCacheTF])**
+    * Returns a Promise resolving an array of `Set` objects belonging to this Event
+    * **fromCacheTF** - boolean value for if the value should be retrieved from cache. Defaults to true
+* **getPlayers([fromCacheTF])**
+    * Returns a Promise resolving an array of `Player` objects belonging to this Event
+    * **fromCacheTF** - boolean value for if the value should be retrieved from cache. Defaults to true
 
 #### Getters
 * **getName()**
@@ -454,6 +460,14 @@ phase2.on('ready', function(){
 * **getPhaseGroups([fromCacheTF])**
     * Returns a Promise resolving an array of `PhaseGroup` objects belonging to this Phase
     * **fromCacheTF** - boolean value for if the value should be retrieved from cache. Defaults to true
+* **getSets([fromCacheTF])**
+    * Returns a Promise resolving an array of `Set` objects belonging to this Phase
+    * **fromCacheTF** - boolean value for if the value should be retrieved from cache. Defaults to true
+* **getPlayers([fromCacheTF])**
+    * Returns a Promise resolving an array of `Player` objects belonging to this Phase
+    * **fromCacheTF** - boolean value for if the value should be retrieved from cache. Defaults to true
+
+    
 
 #### Getters
 * **getName()**

--- a/lib/Event.js
+++ b/lib/Event.js
@@ -263,7 +263,57 @@ class Event extends EventEmitter{
 			log.error('Event.getEventPhaseGroups: ' + err);
 			throw err;
 		}
+	}
 
+	async getSets(fromCacheTF=true){
+		log.debug('Event.getSets called');
+		try{
+			let cacheKey = format('event::%s::%s::sets', this.tournamentId, this.eventId);
+			if(fromCacheTF){
+				let cached = await Cache.get(cacheKey);
+				if(cached) return cached;
+			}
+
+			let phases = await this.getEventPhases();
+			let sets = await Promise.all(
+				phases.map(async (phase) => {
+					return await phase.getSets();
+				})
+			);
+
+			sets = _.flatten(sets);
+			if(fromCacheTF) await Cache.set(cacheKey, sets);
+			return sets;
+		} catch(e){
+			log.error('Event.getSets error: %s', e);
+			throw e;
+		}
+	}
+
+	async getPlayers(fromCacheTF=true){
+		log.debug('Event.getSets called');
+		try{
+			let cacheKey = format('event::%s::%s::players', this.tournamentId, this.eventId);
+			if(fromCacheTF){
+				let cached = await Cache.get(cacheKey);
+				if(cached) return cached;
+			}
+
+			let phases = await this.getEventPhases();
+			let players = await Promise.all(
+				phases.map(async (phase) => {
+					return await phase.getPlayers();
+				})
+			);
+
+			players = _.flatten(players);
+			players = _.uniqBy(players, 'id');
+			if(fromCacheTF) await Cache.set(cacheKey, players);
+			return players;
+		} catch(e){
+			log.error('Event.getSets error: %s', e);
+			throw e;
+		}
 	}
 
 	/** SIMPLE GETTERS **/

--- a/lib/Phase.js
+++ b/lib/Phase.js
@@ -124,7 +124,7 @@ class Phase extends EventEmitter{
 	}
 
 	/** PROMISES **/
-	async getPhaseGroups(fromCacheTF){
+	async getPhaseGroups(fromCacheTF=true){
 		log.debug('Phase.getGroups called');
 
 		if(fromCacheTF == null || fromCacheTF == undefined)
@@ -155,7 +155,60 @@ class Phase extends EventEmitter{
 			log.error('Phase.getGroups: ' + err);
 			throw err;
 		}
+	}
 
+	async getSets(fromCacheTF=true){
+		log.debug('Phase.getSets called');
+
+		try{
+			let cacheKey = format('phase::%s::sets', this.id);
+			if(fromCacheTF){
+				let cached = await Cache.get(cacheKey);
+				if(cached) return cached;
+			}
+
+			let phaseGroups = await this.getPhaseGroups(fromCacheTF);
+			let sets = await Promise.all(
+				phaseGroups.map(async (group) => {
+					return await group.getSets();
+				})
+			);
+
+			sets = _.flatten(sets);
+			if(fromCacheTF) await Cache.set(cacheKey, sets);
+			return sets;
+
+		} catch(e){
+			log.error('Phase.getSets error: %s', e);
+			throw e;
+		}
+	}
+
+	async getPlayers(fromCacheTF=true){
+		log.debug('Phase.getPlayers called');
+
+		try{
+			let cacheKey = format('phase::%s::players', this.id);
+			if(fromCacheTF){
+				let cached = await Cache.get(cacheKey);
+				if(cached) return cached;
+			}
+
+			let phaseGroups = await this.getPhaseGroups(fromCacheTF);
+			let players = await Promise.all(
+				phaseGroups.map(async (group) => {
+					return await group.getPlayers();
+				})
+			);
+
+			players = _.flatten(players);
+			players = _.uniqBy(players, 'id');
+			if(fromCacheTF) await Cache.set(cacheKey, players);
+			return players;
+		} catch(e){
+			log.error('Phase.getPlayers error: %s', e);
+			throw e;
+		}
 	}
 
 	/** SIMPLE GETTERS **/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Brandon L Cooke",
     "url": "http://linkedin.com/in/BrandonCookeDev"
   },
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Node.JS wrapper for the Smash.gg public API Edit",
   "main": "index.js",
   "engines": {

--- a/patchnotes/patchnotes.txt
+++ b/patchnotes/patchnotes.txt
@@ -1,6 +1,6 @@
 /** Patch Notes **/
 
-/** 2.1.2 **/
+/** 2.1.2 :: 07-09-2018 **/
 * Added methods that get sets and players for a given phase
 * Added methods that get sets and players for a given event
 * Fixed unit test logic that was still caching old results

--- a/patchnotes/patchnotes.txt
+++ b/patchnotes/patchnotes.txt
@@ -1,5 +1,10 @@
 /** Patch Notes **/
 
+/** 2.1.2 **/
+* Added methods that get sets and players for a given phase
+* Added methods that get sets and players for a given event
+* Fixed unit test logic that was still caching old results
+
 /** 2.1.1 **/
 * Whoops... Forgot to expose VideoGame to index.js
 

--- a/test/testEvent.js
+++ b/test/testEvent.js
@@ -6,6 +6,8 @@ Promise = require('bluebird');
 let _ = require('lodash');
 let moment = require('moment');
 
+let Set = require('../lib/Set');
+let Player = require('../lib/Player');
 let Event = require('../lib/Event');
 let Phase = require('../lib/Phase');
 let PhaseGroup = require('../lib/PhaseGroup');
@@ -65,7 +67,7 @@ function loadEventViaId(id, options){
 
 describe('Smash GG Event', function(){
 
-	before(function(){
+	beforeEach(function(){
 		Cache.flush();
 	});
 
@@ -202,6 +204,44 @@ describe('Smash GG Event', function(){
 		groups2.forEach(group => {
 			expect(group).to.be.instanceof(PhaseGroup);
 		});
+
+		return true;
+	})
+
+	it('should correctly get all sets from an event', async function(){
+		this.timeout(30000);
+
+		let sets1 = await event1.getSets();
+		let sets2 = await event2.getSets();
+
+		expect(sets1.length).to.be.equal(429);
+		expect(sets2.length).to.be.equal(1354);
+
+		sets1.forEach(set => {
+			expect(set).to.be.instanceof(Set);
+		})
+		sets2.forEach(set => {
+			expect(set).to.be.instanceof(Set);
+		})
+
+		return true;
+	})
+
+	it('should correctly get all players from an event', async function(){
+		this.timeout(30000);
+		
+		let players1 = await event1.getPlayers();
+		let players2 = await event2.getPlayers();
+
+		expect(players1.length).to.be.equal(156);
+		expect(players2.length).to.be.equal(678);
+
+		players1.forEach(set => {
+			expect(set).to.be.instanceof(Player);
+		})
+		players2.forEach(set => {
+			expect(set).to.be.instanceof(Player);
+		})
 
 		return true;
 	})

--- a/test/testPhase.js
+++ b/test/testPhase.js
@@ -6,6 +6,8 @@ let _ = require('lodash');
 let Phase = require('../lib/Phase');
 let PhaseGroup = require('../lib/PhaseGroup');
 let Cache = require('../lib/util/Cache').getInstance();
+let Set = require('../lib/Set');
+let Player = require('../lib/Player');
 
 let chai = require('chai');
 let cap = require('chai-as-promised');
@@ -35,7 +37,7 @@ function loadPhase(id, options){
 
 describe('Smash GG Phase', function(){
 
-	before(function(){
+	beforeEach(function(){
 		Cache.flush();
 	});
 
@@ -51,9 +53,9 @@ describe('Smash GG Phase', function(){
 	it('should implement the convenience methods correctly', async function(){
 		this.timeout(10000);
 
-		let cPhase1 = await Phase.getPhase(ID1);
+		let cPhase1 = await Phase.getPhase(ID1, {rawEncoding: 'utf8'});
 		let cPhase2 = await Phase.getPhase(ID2);
-		let cPhase3 = await Phase.getPhase(ID3);
+		let cPhase3 = await Phase.getPhase(ID3, {rawEncoding: 'base64'});
 
 		expect(cPhase1.data).to.deep.equal(phase1.data);
 		expect(cPhase2.data).to.deep.equal(phase2.data);
@@ -106,4 +108,42 @@ describe('Smash GG Phase', function(){
 
 		return true;
 	});
+
+	it('should correctly get all sets for a phase', async function(){
+		this.timeout(30000);
+
+		let sets1 = await phase1.getSets();
+		let sets2 = await phase2.getSets();
+
+		expect(sets1.length).to.be.equal(216);
+		expect(sets2.length).to.be.equal(1260);
+
+		sets1.forEach(set => {
+			expect(set).to.be.instanceof(Set);
+		})
+		sets2.forEach(set => {
+			expect(set).to.be.instanceof(Set);
+		})
+
+		return true;
+	})
+
+	it('should correctly get all players for a phase', async function(){
+		this.timeout(30000);
+		
+		let players1 = await phase1.getPlayers();
+		let players2 = await phase2.getPlayers();
+
+		expect(players1.length).to.be.equal(156);
+		expect(players2.length).to.be.equal(678);
+
+		players1.forEach(set => {
+			expect(set).to.be.instanceof(Player);
+		})
+		players2.forEach(set => {
+			expect(set).to.be.instanceof(Player);
+		})
+
+		return true;
+	})
 });

--- a/test/testPhaseGroup.js
+++ b/test/testPhaseGroup.js
@@ -40,7 +40,7 @@ function loadPhaseGroup(id, options){
 
 describe('Smash GG Phase Group', function(){
 
-	before(function(){
+	beforeEach(function(){
 		Cache.flush();
 	});
 
@@ -53,7 +53,7 @@ describe('Smash GG Phase Group', function(){
 
 	it('should implement the convenience methods correctly', async function(){
 		this.timeout(5000);
-		let cPhaseGroup3 = await PhaseGroup.getPhaseGroup(ID3);
+		let cPhaseGroup3 = await PhaseGroup.getPhaseGroup(ID3, {rawEncoding: 'base64'});
 		expect(cPhaseGroup3.data).to.deep.equal(phaseGroup3.data);
 		return true;
 	})

--- a/test/testTournament.js
+++ b/test/testTournament.js
@@ -45,7 +45,7 @@ function loadTournament(name, options){
 
 describe('Smash GG Tournament', function(){
 
-	before(function(){
+	beforeEach(function(){
 		Cache.flush();
 	});
 
@@ -86,11 +86,13 @@ describe('Smash GG Tournament', function(){
 	it('should implement convenience methods correctly', async function(){
 		this.timeout(15000);
 
-		let cTournament1 = await Tournament.getTournament(TOURNAMENT_NAME1);
-		let cTournament2 = await Tournament.getTournament(TOURNAMENT_NAME2);
+		let cTournament1 = await Tournament.getTournament(TOURNAMENT_NAME1, {rawEncoding: 'utf8'});
+		let cTournament2 = await Tournament.getTournament(TOURNAMENT_NAME2, {rawEncoding: 'base64'});
+		let cTournament3 = await Tournament.getTournament(TOURNAMENT_NAME3);
 
 		expect(cTournament1.data).to.deep.equal(tournament1.data);
 		expect(cTournament2.data).to.deep.equal(tournament2.data);
+		expect(cTournament3.data).to.deep.equal(tournament3.data);
 
 		return true;
 	})


### PR DESCRIPTION
Previously unavailable getSets() and getPlayers() methods now available for `Event` and `Phase` objects